### PR TITLE
Fix typo in "trading with reinforcement learning part two" notebook

### DIFF
--- a/notebooks/trading-with-reinforcement-learning-in-python-part-two-application.ipynb
+++ b/notebooks/trading-with-reinforcement-learning-in-python-part-two-application.ipynb
@@ -77,7 +77,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This function will generate a value between 0 and 1, which will tell us what percentage of the portfolio should buy the asset. $\\theta$, like in the last post, will be the parameters we will optimize using gradient ascent, and $x_t$ will be the input vector at time $t$. For this post, we will assign the input vector as $x_t = [1, r_{t - M}, ... , r_t, F_{t - 1}] $, where $r_t$ is the percent change between the asset at time $t$ and $t - 1$, and $M$ is the number of time series inputs. This means that at every time step, the model will be fed its last position and a series of historical price changes that it can use to calculate its next position. We can calculate all of the positions given price series `x`, and `theta` with the following Python function:"
+    "This function will generate a value between 0 and 1, which will tell us what percentage of the portfolio should buy the asset. $\\theta$, like in the last post, will be the parameters we will optimize using gradient ascent, and $x_t$ will be the input vector at time $t$. For this post, we will assign the input vector as $x_t = [1, r_{t - M}, ... , r_t, F_{t - 1}] $, where $r_t$ is the absolute change between the asset at time $t$ and $t - 1$, and $M$ is the number of time series inputs. This means that at every time step, the model will be fed its last position and a series of historical price changes that it can use to calculate its next position. We can calculate all of the positions given price series `x`, and `theta` with the following Python function:"
    ]
   },
   {


### PR DESCRIPTION
In the paper which you referenced **r_t** is defined as the absolute difference between value at **t** and **(t-1)**, not the percentage change. Also you used a **diff()** function to calculate this in the code below, so I think it's a typo here and I fixed it.